### PR TITLE
fix domain default param in config

### DIFF
--- a/lightning-config.php
+++ b/lightning-config.php
@@ -7,7 +7,7 @@ use PhpLightning\Config\LightningConfig;
 
 return (new LightningConfig())
     ->setMode('test')
-    ->setDomain('https://your-domain.com')
+    ->setDomain('your-domain.com')
     ->setReceiver('custom-receiver')
     ->setMinSendable(100_000)
     ->setMaxSendable(10_000_000_000)

--- a/src/Config/LightningConfig.php
+++ b/src/Config/LightningConfig.php
@@ -29,7 +29,8 @@ final class LightningConfig implements JsonSerializable
 
     public function setDomain(string $domain): self
     {
-        $this->domain = $domain;
+        $parseUrl = parse_url($domain);
+        $this->domain = $parseUrl['host'] ?? $domain;
         return $this;
     }
 

--- a/tests/Unit/Config/LightningConfigTest.php
+++ b/tests/Unit/Config/LightningConfigTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLightningTest\Unit\Config;
+
+use PhpLightning\Config\Backend\LnBitsBackendConfig;
+use PhpLightning\Config\LightningConfig;
+use PHPUnit\Framework\TestCase;
+
+final class LightningConfigTest extends TestCase
+{
+    public function test_default_values(): void
+    {
+        $config = new LightningConfig();
+
+        self::assertSame([
+            'mode' => 'test',
+            'backends' => [],
+        ], $config->jsonSerialize());
+    }
+
+    public function test_mode(): void
+    {
+        $config = (new LightningConfig())
+            ->setMode('prod');
+
+        self::assertSame([
+            'mode' => 'prod',
+            'backends' => [],
+        ], $config->jsonSerialize());
+    }
+
+    public function test_domain_with_scheme(): void
+    {
+        $config = (new LightningConfig())
+            ->setDomain('https://your-domain.com');
+
+        self::assertSame([
+            'mode' => 'test',
+            'backends' => [],
+            'domain' => 'your-domain.com',
+        ], $config->jsonSerialize());
+    }
+
+    public function test_domain_without_scheme(): void
+    {
+        $config = (new LightningConfig())
+            ->setDomain('your-domain.com');
+
+        self::assertSame([
+            'mode' => 'test',
+            'backends' => [],
+            'domain' => 'your-domain.com',
+        ], $config->jsonSerialize());
+    }
+
+    public function test_receiver(): void
+    {
+        $config = (new LightningConfig())
+            ->setReceiver('custom-receiver');
+
+        self::assertSame([
+            'mode' => 'test',
+            'backends' => [],
+            'receiver' => 'custom-receiver',
+        ], $config->jsonSerialize());
+    }
+
+    public function test_min_sendable(): void
+    {
+        $config = (new LightningConfig())
+            ->setMinSendable(100_000);
+
+        self::assertSame([
+            'mode' => 'test',
+            'backends' => [],
+            'min-sendable' => 100_000,
+        ], $config->jsonSerialize());
+    }
+
+    public function test_max_sendable(): void
+    {
+        $config = (new LightningConfig())
+            ->setMaxSendable(10_000_000_000);
+
+        self::assertSame([
+            'mode' => 'test',
+            'backends' => [],
+            'max-sendable' => 10_000_000_000,
+        ], $config->jsonSerialize());
+    }
+
+    public function test_ln_bits_backend(): void
+    {
+        $config = (new LightningConfig())
+            ->addBackend(
+                (new LnBitsBackendConfig())
+                    ->setApiEndpoint('http://localhost:5000')
+                    ->setApiKey('XYZ'),
+            );
+
+        self::assertSame([
+            'mode' => 'test',
+            'backends' => [
+                'lnbits' => [
+                    'api_endpoint' => 'http://localhost:5000',
+                    'api_key' => 'XYZ',
+                ],
+            ],
+        ], $config->jsonSerialize());
+    }
+}


### PR DESCRIPTION
## 📚 Description

domain itself should not have protocol information, it leads to have double protocol in callback url

## 🔖 Changes

removed `https://` from default domain value
