### PR TITLE
Get callback-url in index.php when no GET amount

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -23,7 +23,11 @@ $backend = 'lnbits';
 $milliSats = (int)($argv[1] ?? $_GET['amount'] ?? 0);
 
 try {
-    echo Lightning::generateInvoice($milliSats, $backend);
+    if ($milliSats === 0) {
+        echo Lightning::getCallbackUrl();
+    } else {
+        echo Lightning::generateInvoice($milliSats, $backend);
+    }
 } catch (Throwable $e) {
     echo $e->getMessage();
 }

--- a/src/Lightning.php
+++ b/src/Lightning.php
@@ -14,6 +14,13 @@ final class Lightning
 
     private const CONFIG_LOCAL_FILE = 'lightning-config-local.php';
 
+    public static function getCallbackUrl(): string
+    {
+        $invoice = (new InvoiceFacade())->getCallbackUrl();
+
+        return json_encode($invoice, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+    }
+
     public static function generateInvoice(int $amount, string $backend = 'lnbits'): string
     {
         $invoice = (new InvoiceFacade())->generateInvoice($amount, $backend);

--- a/src/Lightning.php
+++ b/src/Lightning.php
@@ -29,6 +29,8 @@ final class Lightning
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * @return Closure(GacelaConfig):void
      */
     public static function configFn(): Closure

--- a/tests/Feature/LightningFeature.php
+++ b/tests/Feature/LightningFeature.php
@@ -18,6 +18,23 @@ use PHPUnit\Framework\TestCase;
 
 final class LightningFeature extends TestCase
 {
+    public function test_get_get_callback_url(): void
+    {
+        $this->bootstrapGacela();
+        $this->mockLnPaymentRequest();
+
+        $json = Lightning::getCallbackUrl();
+
+        self::assertEquals([
+            'callback' => 'https://domain.com/receiver',
+            'maxSendable' => 10_000,
+            'minSendable' => 1_000,
+            'metadata' => '[["text/plain","Pay to receiver@domain.com"],["text/identifier","receiver@domain.com"]]',
+            'tag' => 'payRequest',
+            'commentAllowed' => false,
+        ], json_decode($json, true));
+    }
+
     public function test_ln_bits_feature(): void
     {
         $this->bootstrapGacela();
@@ -43,6 +60,8 @@ final class LightningFeature extends TestCase
             $config->resetInMemoryCache();
             $config->addAppConfigKeyValues(
                 (new LightningConfig())
+                    ->setDomain('domain.com')
+                    ->setReceiver('receiver')
                     ->setSendableRange(1_000, 10_000)
                     ->addBackend(
                         (new LnBitsBackendConfig())


### PR DESCRIPTION
## 📚 Description

As you suggested in a private message, I implemented this draft idea: 
```php
if(!$_GET["amount"] {
   // display content of vendor/bin/lnaddress callback-url
}  else {
  // same content of the current index.php
}
```

## 🖼️  Demo

https://user-images.githubusercontent.com/5256287/230178424-f6eb298b-fa47-42d2-8f63-738726ca8884.mov

