### PR TITLE
Allow passing custom LightningConfig to Lightning::configFn()

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -6,6 +6,8 @@ header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json");
 
 use Gacela\Framework\Gacela;
+use PhpLightning\Config\Backend\LnBitsBackendConfig;
+use PhpLightning\Config\LightningConfig;
 use PhpLightning\Lightning;
 
 $cwd = (string)getcwd();
@@ -15,7 +17,19 @@ if (!file_exists($autoloadPath = $cwd . '/vendor/autoload.php')) {
 
 require $autoloadPath;
 
-Gacela::bootstrap($cwd, Lightning::configFn());
+$lightningConfig = (new LightningConfig())
+    ->setDomain($_SERVER['HTTP_HOST'] ?? '')
+    ->setReceiver(str_replace('.php', '', basename(__FILE__)))
+    ->setSendableRange(100_000, 10_000_000_000)
+    ->setCallbackUrl('https://sndbox.localhost.pe/.well-known/lnurlp/test')
+    ->addBackend(
+        (new LnBitsBackendConfig())
+            ->setApiEndpoint('http://localhost:5000')
+            ->setApiKey('feeddeadbeefcafe')
+    );
+
+Gacela::bootstrap($cwd, Lightning::configFn($lightningConfig));
+
 
 // For now lnbits is the only backend supported
 $backend = 'lnbits';

--- a/public/index.php
+++ b/public/index.php
@@ -47,3 +47,4 @@ try {
     echo $e->getMessage();
 }
 echo PHP_EOL;
+?>

--- a/public/index.php
+++ b/public/index.php
@@ -11,6 +11,7 @@ use PhpLightning\Config\LightningConfig;
 use PhpLightning\Lightning;
 
 $cwd = (string)getcwd();
+// $cwd = "/opt/lnaddress/demo/demo-lnaddress/";            // path to composer working directory (to be reviewed)
 if (!file_exists($autoloadPath = $cwd . '/vendor/autoload.php')) {
     exit("Cannot load composer's autoload file: " . $autoloadPath);
 }

--- a/public/index.php
+++ b/public/index.php
@@ -24,8 +24,8 @@ $lightningConfig = (new LightningConfig())
     ->setCallbackUrl('https://'.$_SERVER["HTTP_HOST"].$_SERVER["REQUEST_URI"])
     ->addBackend(
         (new LnBitsBackendConfig())
-            ->setApiEndpoint('http://localhost:5000')
-            ->setApiKey('feeddeadbeefcafe')
+            ->setApiEndpoint('http://localhost:5000')       // paste your lnbits endpoint here
+            ->setApiKey('Invoice LNbits API key goes here') // paste your lnbits invoice key here
     );
 
 Gacela::bootstrap($cwd, Lightning::configFn($lightningConfig));

--- a/public/index.php
+++ b/public/index.php
@@ -21,7 +21,7 @@ $lightningConfig = (new LightningConfig())
     ->setDomain($_SERVER['HTTP_HOST'] ?? '')
     ->setReceiver(str_replace('.php', '', basename(__FILE__)))
     ->setSendableRange(100_000, 10_000_000_000)
-    ->setCallbackUrl('https://sndbox.localhost.pe/.well-known/lnurlp/test')
+    ->setCallbackUrl('https://'.$_SERVER["HTTP_HOST"].$_SERVER["REQUEST_URI"])
     ->addBackend(
         (new LnBitsBackendConfig())
             ->setApiEndpoint('http://localhost:5000')

--- a/src/Lightning.php
+++ b/src/Lightning.php
@@ -6,6 +6,7 @@ namespace PhpLightning;
 
 use Closure;
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use PhpLightning\Config\LightningConfig;
 use PhpLightning\Invoice\InvoiceFacade;
 
 final class Lightning
@@ -33,9 +34,13 @@ final class Lightning
      *
      * @return Closure(GacelaConfig):void
      */
-    public static function configFn(): Closure
+    public static function configFn(?LightningConfig $lightningConfig = null): Closure
     {
-        return static function (GacelaConfig $config): void {
+        return static function (GacelaConfig $config) use ($lightningConfig): void {
+            if ($lightningConfig !== null) {
+                /** @psalm-suppress MixedArgumentTypeCoercion */
+                $config->addAppConfigKeyValues($lightningConfig->jsonSerialize());
+            }
             $config->addAppConfig(self::CONFIG_FILE, self::CONFIG_LOCAL_FILE);
             $config->setFileCacheEnabled(true);
             $config->setFileCacheDirectory('data/.cache');


### PR DESCRIPTION
## 📚 Description

As talked, you suggested that this would allow having `username.php` file with the following content.

## 🔖 Changes

- Allow passing custom config to `Lightning::configFn()`

> WIP: callbackurl can be automatically guessed too
'https://'.$_SERVER["HTTP_HOST"].$_SERVER["REQUEST_URI"]