### PR TITLE
Allow add backends as json

### DIFF
--- a/lightning-config.dist.php
+++ b/lightning-config.dist.php
@@ -11,10 +11,6 @@ return (new LightningConfig())
     ->setSendableRange(min: 100_000, max: 10_000_000_000)
     ->setCallbackUrl('localhost:8000/callback')
     ->setBackends([
-        'user-1' => (new LnBitsBackendConfig())
-            ->setApiEndpoint('http://localhost:5000')
-            ->setApiKey('api_key-1'),
-        'user-2' => (new LnBitsBackendConfig())
-            ->setApiEndpoint('http://localhost:5000')
-            ->setApiKey('api_key-2')
+        'user-1' => LnBitsBackendConfig::withEndpointAndKey('http://localhost:5000', 'api_key-1'),
+        'user-2' => LnBitsBackendConfig::withEndpointAndKey('http://localhost:5000', 'api_key-2'),
     ]);

--- a/src/Config/Backend/LnBitsBackendConfig.php
+++ b/src/Config/Backend/LnBitsBackendConfig.php
@@ -9,23 +9,15 @@ final class LnBitsBackendConfig implements BackendConfigInterface
     private string $apiEndpoint = 'http://localhost:5000';
     private string $apiKey = '';
 
-    public static function withApiEndpointAndKey(string $endpoint, string $key): self
+    private function __construct()
+    {
+    }
+
+    public static function withEndpointAndKey(string $endpoint, string $key): self
     {
         return (new self())
             ->setApiEndpoint($endpoint)
             ->setApiKey($key);
-    }
-
-    public function setApiEndpoint(string $apiEndpoint): self
-    {
-        $this->apiEndpoint = rtrim($apiEndpoint, '/');
-        return $this;
-    }
-
-    public function setApiKey(string $apiKey): self
-    {
-        $this->apiKey = $apiKey;
-        return $this;
     }
 
     /**
@@ -40,5 +32,17 @@ final class LnBitsBackendConfig implements BackendConfigInterface
             'api_endpoint' => $this->apiEndpoint,
             'api_key' => $this->apiKey,
         ];
+    }
+
+    private function setApiEndpoint(string $apiEndpoint): self
+    {
+        $this->apiEndpoint = rtrim($apiEndpoint, '/');
+        return $this;
+    }
+
+    private function setApiKey(string $apiKey): self
+    {
+        $this->apiKey = $apiKey;
+        return $this;
     }
 }

--- a/src/Config/Backend/LnBitsBackendConfig.php
+++ b/src/Config/Backend/LnBitsBackendConfig.php
@@ -9,6 +9,13 @@ final class LnBitsBackendConfig implements BackendConfigInterface
     private string $apiEndpoint = 'http://localhost:5000';
     private string $apiKey = '';
 
+    public static function withApiEndpointAndKey(string $endpoint, string $key): self
+    {
+        return (new self())
+            ->setApiEndpoint($endpoint)
+            ->setApiKey($key);
+    }
+
     public function setApiEndpoint(string $apiEndpoint): self
     {
         $this->apiEndpoint = rtrim($apiEndpoint, '/');

--- a/src/Config/LightningConfig.php
+++ b/src/Config/LightningConfig.php
@@ -70,7 +70,7 @@ final class LightningConfig implements JsonSerializable
         foreach ($json as $user => $settings) {
             $this->addBackend(
                 $user,
-                LnBitsBackendConfig::withApiEndpointAndKey(
+                LnBitsBackendConfig::withEndpointAndKey(
                     $settings['api_endpoint'] ?? '',
                     $settings['api_key'] ?? '',
                 ),

--- a/src/Config/LightningConfig.php
+++ b/src/Config/LightningConfig.php
@@ -6,6 +6,7 @@ namespace PhpLightning\Config;
 
 use JsonSerializable;
 use PhpLightning\Config\Backend\BackendConfigInterface;
+use PhpLightning\Config\Backend\LnBitsBackendConfig;
 use PhpLightning\Shared\Value\SendableRange;
 
 final class LightningConfig implements JsonSerializable
@@ -57,6 +58,25 @@ final class LightningConfig implements JsonSerializable
     {
         $this->backends ??= new BackendsConfig();
         $this->backends->add($username, $backendConfig);
+        return $this;
+    }
+
+    public function addBackendsAsJson(string $path): self
+    {
+        $jsonAsString = (string)file_get_contents($path);
+        /** @var array<string, array{api_endpoint?:string, api_key?: string}> $json */
+        $json = json_decode($jsonAsString, true);
+
+        foreach ($json as $user => $settings) {
+            $this->addBackend(
+                $user,
+                LnBitsBackendConfig::withApiEndpointAndKey(
+                    $settings['api_endpoint'] ?? '',
+                    $settings['api_key'] ?? '',
+                ),
+            );
+        }
+
         return $this;
     }
 

--- a/tests/Feature/InvoiceFacadeTest.php
+++ b/tests/Feature/InvoiceFacadeTest.php
@@ -9,7 +9,6 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Gacela;
-use PhpLightning\Config\Backend\LnBitsBackendConfig;
 use PhpLightning\Config\LightningConfig;
 use PhpLightning\Invoice\InvoiceDependencyProvider;
 use PhpLightning\Invoice\InvoiceFacade;
@@ -72,12 +71,8 @@ final class InvoiceFacadeTest extends TestCase
                     ->setDomain('domain.com')
                     ->setReceiver('receiver')
                     ->setSendableRange(1_000, 10_000)
-                    ->addBackend(
-                        'username',
-                        (new LnBitsBackendConfig())
-                            ->setApiEndpoint('http://localhost:5000')
-                            ->setApiKey('XYZ'),
-                    )->jsonSerialize(),
+                    ->addBackendsAsJson(__DIR__ . DIRECTORY_SEPARATOR . 'nostr.json')
+                    ->jsonSerialize(),
             );
         });
     }

--- a/tests/Feature/InvoiceFacadeTest.php
+++ b/tests/Feature/InvoiceFacadeTest.php
@@ -29,13 +29,13 @@ final class InvoiceFacadeTest extends TestCase
         $this->bootstrapGacela();
         $this->mockLnPaymentRequest();
 
-        $json = $this->facade->getCallbackUrl('username');
+        $json = $this->facade->getCallbackUrl('bob');
 
         self::assertEquals([
             'callback' => 'https://callback.url/receiver',
             'maxSendable' => 10_000,
             'minSendable' => 1_000,
-            'metadata' => '[["text/plain","Pay to username@domain.com"],["text/identifier","username@domain.com"]]',
+            'metadata' => '[["text/plain","Pay to bob@domain.com"],["text/identifier","bob@domain.com"]]',
             'tag' => 'payRequest',
             'commentAllowed' => false,
         ], $json);
@@ -46,7 +46,7 @@ final class InvoiceFacadeTest extends TestCase
         $this->bootstrapGacela();
         $this->mockLnPaymentRequest();
 
-        $json = $this->facade->generateInvoice('username', 2_000, 'lnbits');
+        $json = $this->facade->generateInvoice('alice', 2_000, 'lnbits');
 
         self::assertEquals([
             'pr' => 'lnbc10u1pjzh489...fake payment_request',

--- a/tests/Feature/nostr.json
+++ b/tests/Feature/nostr.json
@@ -1,6 +1,10 @@
 {
-    "username": {
+    "bob": {
         "api_key": "abc...123",
+        "api_endpoint": "http://localhost:5000"
+    },
+    "alice": {
+        "api_key": "def...456",
         "api_endpoint": "http://localhost:5000"
     }
 }

--- a/tests/Feature/nostr.json
+++ b/tests/Feature/nostr.json
@@ -1,0 +1,6 @@
+{
+    "username": {
+        "api_key": "abc...123",
+        "api_endpoint": "http://localhost:5000"
+    }
+}

--- a/tests/Unit/Config/LightningConfigTest.php
+++ b/tests/Unit/Config/LightningConfigTest.php
@@ -63,9 +63,7 @@ final class LightningConfigTest extends TestCase
         $config = (new LightningConfig())
             ->addBackend(
                 'username',
-                (new LnBitsBackendConfig())
-                    ->setApiEndpoint('http://localhost:5000/')
-                    ->setApiKey('XYZ'),
+                LnBitsBackendConfig::withEndpointAndKey('http://localhost:5000/', 'XYZ'),
             );
 
         self::assertEquals([


### PR DESCRIPTION
## 📚 Description

Currently, if you want to support settings for multiple users you need to update the current config file and add them one by one, which can be tedious to do.

The goal is to extract that part of configuration into a different stored-placed, and the simplest I could think of is a JSON file.

> Inspired by the [nostr NIP-05](https://github.com/nostr-protocol/nips/blob/master/05.md).

## 🔖 Changes

- Allow defining a custom JSON file where you can store the different users with their own API settings.

You can specify where is that JSON file using the `addBackendsAsJson()` from the `LightningConfig` object.
