### PR TITLE
Add invoice memo configuration

### DIFF
--- a/lightning-config.dist.php
+++ b/lightning-config.dist.php
@@ -9,6 +9,7 @@ return (new LightningConfig())
     ->setReceiver('default-receiver')
     ->setDescriptionTemplate('Pay to %s')
     ->setSuccessMessage('Payment received!')
+    ->setInvoiceMemo('')
     ->setSendableRange(min: 100_000, max: 10_000_000_000)
     ->setCallbackUrl('localhost:8000/callback')
     ->addBackendsFile(getcwd() . DIRECTORY_SEPARATOR . 'nostr.json');

--- a/src/Config/LightningConfig.php
+++ b/src/Config/LightningConfig.php
@@ -18,6 +18,7 @@ final class LightningConfig implements JsonSerializable
     private ?string $callbackUrl = null;
     private ?string $descriptionTemplate = null;
     private ?string $successMessage = null;
+    private ?string $invoiceMemo = null;
 
     public function setDomain(string $domain): self
     {
@@ -53,6 +54,12 @@ final class LightningConfig implements JsonSerializable
     public function setSuccessMessage(string $message): self
     {
         $this->successMessage = $message;
+        return $this;
+    }
+
+    public function setInvoiceMemo(string $memo): self
+    {
+        $this->invoiceMemo = $memo;
         return $this;
     }
 
@@ -111,6 +118,9 @@ final class LightningConfig implements JsonSerializable
         }
         if ($this->successMessage !== null) {
             $result['success-message'] = $this->successMessage;
+        }
+        if ($this->invoiceMemo !== null) {
+            $result['invoice-memo'] = $this->invoiceMemo;
         }
 
         return $result;

--- a/src/Invoice/Application/InvoiceGenerator.php
+++ b/src/Invoice/Application/InvoiceGenerator.php
@@ -19,6 +19,7 @@ final readonly class InvoiceGenerator
         private string $lnAddress,
         private string $descriptionTemplate,
         private string $successMessage,
+        private string $memo,
     ) {
     }
 
@@ -36,7 +37,7 @@ final readonly class InvoiceGenerator
         $imageMetadata = '';
         $metadata = '[["text/plain","' . $description . '"],["text/identifier","' . $this->lnAddress . '"]' . $imageMetadata . ']';
 
-        $invoice = $this->backendInvoice->requestInvoice((int)($milliSats / 1000), $metadata);
+        $invoice = $this->backendInvoice->requestInvoice((int)($milliSats / 1000), $metadata, $this->memo);
 
         return $this->mapResponseAsArray($invoice);
     }

--- a/src/Invoice/Domain/BackendInvoice/BackendInvoiceInterface.php
+++ b/src/Invoice/Domain/BackendInvoice/BackendInvoiceInterface.php
@@ -8,5 +8,5 @@ use PhpLightning\Shared\Transfer\InvoiceTransfer;
 
 interface BackendInvoiceInterface
 {
-    public function requestInvoice(int $satsAmount, string $metadata): InvoiceTransfer;
+    public function requestInvoice(int $satsAmount, string $metadata, string $memo = ''): InvoiceTransfer;
 }

--- a/src/Invoice/Domain/BackendInvoice/EmptyBackendInvoice.php
+++ b/src/Invoice/Domain/BackendInvoice/EmptyBackendInvoice.php
@@ -12,7 +12,7 @@ final readonly class EmptyBackendInvoice implements BackendInvoiceInterface
     {
     }
 
-    public function requestInvoice(int $satsAmount, string $metadata): InvoiceTransfer
+    public function requestInvoice(int $satsAmount, string $metadata, string $memo = ''): InvoiceTransfer
     {
         return new InvoiceTransfer(status: 'ERROR', error: 'Unknown Backend: ' . $this->name);
     }

--- a/src/Invoice/Domain/BackendInvoice/LnbitsBackendInvoice.php
+++ b/src/Invoice/Domain/BackendInvoice/LnbitsBackendInvoice.php
@@ -18,13 +18,14 @@ final class LnbitsBackendInvoice implements BackendInvoiceInterface
     ) {
     }
 
-    public function requestInvoice(int $satsAmount, string $metadata = ''): InvoiceTransfer
+    public function requestInvoice(int $satsAmount, string $metadata = '', string $memo = ''): InvoiceTransfer
     {
         $endpoint = $this->options['api_endpoint'] . '/api/v1/payments';
 
         $content = [
             'out' => false,
             'amount' => $satsAmount,
+            'memo' => $memo,
             'unhashed_description' => bin2hex($metadata),
             'description_hash' => hash('sha256', $metadata),
         ];

--- a/src/Invoice/InvoiceConfig.php
+++ b/src/Invoice/InvoiceConfig.php
@@ -64,6 +64,11 @@ final class InvoiceConfig extends AbstractConfig
         return (string)$this->get('success-message', 'Payment received!');
     }
 
+    public function getInvoiceMemo(): string
+    {
+        return (string)$this->get('invoice-memo', '');
+    }
+
     public function getDomain(): string
     {
         return (string)$this->get('domain', $_SERVER['HTTP_HOST'] ?? 'localhost');

--- a/src/Invoice/InvoiceFactory.php
+++ b/src/Invoice/InvoiceFactory.php
@@ -41,6 +41,7 @@ final class InvoiceFactory extends AbstractFactory
             $this->getConfig()->getDefaultLnAddress(),
             $this->getConfig()->getDescriptionTemplate(),
             $this->getConfig()->getSuccessMessage(),
+            $this->getConfig()->getInvoiceMemo(),
         );
     }
 

--- a/tests/Unit/Invoice/Domain/BackendInvoice/LnbitsBackendInvoiceTest.php
+++ b/tests/Unit/Invoice/Domain/BackendInvoice/LnbitsBackendInvoiceTest.php
@@ -21,7 +21,7 @@ final class LnbitsBackendInvoiceTest extends TestCase
             'api_key' => 'key',
         ]);
 
-        $actual = $invoice->requestInvoice(100);
+        $actual = $invoice->requestInvoice(100, '', '');
         $expected = new InvoiceTransfer(error: 'Backend "LnBits" unreachable', status: 'ERROR');
 
         self::assertEquals($expected, $actual);
@@ -40,7 +40,7 @@ final class LnbitsBackendInvoiceTest extends TestCase
             'api_key' => 'key',
         ]);
 
-        $actual = $invoice->requestInvoice(100);
+        $actual = $invoice->requestInvoice(100, '', '');
         $expected = new InvoiceTransfer(bolt11: 'ln1234567890');
 
         self::assertEquals($expected, $actual);

--- a/tests/Unit/Invoice/Domain/LnAddress/InvoiceGeneratorTest.php
+++ b/tests/Unit/Invoice/Domain/LnAddress/InvoiceGeneratorTest.php
@@ -98,7 +98,7 @@ final class InvoiceGeneratorTest extends TestCase
         $backend = $this->createMock(BackendInvoiceInterface::class);
         $backend->expects(self::once())
             ->method('requestInvoice')
-            ->with(2000, $this->anything(), 'Custom memo')
+            ->with(2, $this->anything(), 'Custom memo')
             ->willReturn(new InvoiceTransfer());
 
         $invoice = new InvoiceGenerator(
@@ -109,6 +109,7 @@ final class InvoiceGeneratorTest extends TestCase
             'Payment received!',
             'Custom memo',
         );
+
         $invoice->generateInvoice(2_000);
     }
 }

--- a/tests/Unit/Invoice/Domain/LnAddress/InvoiceGeneratorTest.php
+++ b/tests/Unit/Invoice/Domain/LnAddress/InvoiceGeneratorTest.php
@@ -23,6 +23,7 @@ final class InvoiceGeneratorTest extends TestCase
             'ln@address',
             'Pay to %s',
             'Payment received!',
+            '',
         );
         $actual = $invoice->generateInvoice(100);
 
@@ -44,6 +45,7 @@ final class InvoiceGeneratorTest extends TestCase
             'ln@address',
             'Pay to %s',
             'Payment received!',
+            '',
         );
         $actual = $invoice->generateInvoice(2_000);
 
@@ -73,6 +75,7 @@ final class InvoiceGeneratorTest extends TestCase
             'ln@address',
             'Pay to %s',
             'Payment received!',
+            '',
         );
         $actual = $invoice->generateInvoice(2_000);
 
@@ -88,5 +91,24 @@ final class InvoiceGeneratorTest extends TestCase
             'disposable' => false,
             'error' => null,
         ], $actual);
+    }
+
+    public function test_passes_memo_to_backend(): void
+    {
+        $backend = $this->createMock(BackendInvoiceInterface::class);
+        $backend->expects(self::once())
+            ->method('requestInvoice')
+            ->with(2000, $this->anything(), 'Custom memo')
+            ->willReturn(new InvoiceTransfer());
+
+        $invoice = new InvoiceGenerator(
+            $backend,
+            SendableRange::withMinMax(1_000, 3_000),
+            'ln@address',
+            'Pay to %s',
+            'Payment received!',
+            'Custom memo',
+        );
+        $invoice->generateInvoice(2_000);
     }
 }


### PR DESCRIPTION
## Summary
- allow configuring an invoice memo through `LightningConfig`
- wire memo through `InvoiceFactory` and `InvoiceGenerator`
- support memo in backend invoice requests
- update tests
